### PR TITLE
Fix metrics content type

### DIFF
--- a/ollama_exporter.py
+++ b/ollama_exporter.py
@@ -1,7 +1,7 @@
 import os
 import time
 import httpx
-from fastapi import FastAPI, Request
+from fastapi import FastAPI, Request, Response
 from prometheus_client import Counter, Histogram, generate_latest, CONTENT_TYPE_LATEST
 
 # Configurable Ollama host (via env variable or defaults to localhost)
@@ -19,7 +19,7 @@ LOAD_TIME = Histogram("ollama_load_time_seconds", "Time taken to load models", [
 @app.get("/metrics")
 def metrics():
     """Expose Prometheus metrics."""
-    return generate_latest(), 200, {"Content-Type": CONTENT_TYPE_LATEST}
+    return Response(content=generate_latest(), media_type="text/plain")
 
 @app.post("/api/generate")
 async def generate(request: Request):


### PR DESCRIPTION
I know nothing about Python nor FastAPI, but I was getting a JSON output instead of proper metrics and this seems to solve it:

```
[
    "# HELP python_gc_objects_collected_total Objects collected during gc\n# TYPE python_gc_objects_collected_total counter\npython_gc_objects_collected_total{generation=\"0\"} 353.0\npython_gc_objects_collected_total{generation=\"1\"} 415.0\npython_gc_objects_collected_total{generation=\"2\"} 0.0\n# HELP python_gc_objects_uncollectable_total Uncollectable objects found during GC\n# TYPE python_gc_objects_uncollectable_total counter\npython_gc_objects_uncollectable_total{generation=\"0\"} 0.0\npython_gc_objects_uncollectable_total{generation=\"1\"} 0.0\npython_gc_objects_uncollectable_total{generation=\"2\"} 0.0\n# HELP python_gc_collections_total Number of times this generation was collected\n# TYPE python_gc_collections_total counter\npython_gc_collections_total{generation=\"0\"} 116.0\npython_gc_collections_total{generation=\"1\"} 10.0\npython_gc_collections_total{generation=\"2\"} 0.0\n# HELP python_info Python platform information\n# TYPE python_info gauge\npython_info{implementation=\"CPython\",major=\"3\",minor=\"11\",patchlevel=\"12\",version=\"3.11.12\"} 1.0\n# HELP process_virtual_memory_bytes Virtual memory size in bytes.\n# TYPE process_virtual_memory_bytes gauge\nprocess_virtual_memory_bytes 1.34250496e+08\n# HELP process_resident_memory_bytes Resident memory size in bytes.\n# TYPE process_resident_memory_bytes gauge\nprocess_resident_memory_bytes 4.4449792e+07\n# HELP process_start_time_seconds Start time of the process since unix epoch in seconds.\n# TYPE process_start_time_seconds gauge\nprocess_start_time_seconds 1.74851303243e+09\n# HELP process_cpu_seconds_total Total user and system CPU time spent in seconds.\n# TYPE process_cpu_seconds_total counter\nprocess_cpu_seconds_total 2.8400000000000003\n# HELP process_open_fds Number of open file descriptors.\n# TYPE process_open_fds gauge\nprocess_open_fds 9.0\n# HELP process_max_fds Maximum number of open file descriptors.\n# TYPE process_max_fds gauge\nprocess_max_fds 1024.0\n# HELP ollama_requests_total Total Ollama requests\n# TYPE ollama_requests_total counter\n# HELP ollama_response_seconds Ollama response time\n# TYPE ollama_response_seconds histogram\n# HELP ollama_tokens_generated_total Total tokens generated\n# TYPE ollama_tokens_generated_total counter\n# HELP ollama_eval_total Total evaluation steps performed\n# TYPE ollama_eval_total counter\n# HELP ollama_load_time_seconds Time taken to load models\n# TYPE ollama_load_time_seconds histogram\n",
    200,
    {
        "Content-Type": "text/plain; version=0.0.4; charset=utf-8"
    }
]
```